### PR TITLE
Return scripts in the proper order

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,14 +3,27 @@ const normalize = require("steal-fuzzy-normalize");
 const path = require("path");
 const StealPush = require("steal-push").StealPush;
 
+function isScript(asset) {
+	return asset.type === "script";
+}
+
 class Route {
 	constructor(assets, push, manifest) {
-		this.assets = Object.keys(assets).reduce(function(acc, key){
+		var assets = Object.keys(assets).reduce(function(acc, key){
 			let obj = Object.assign({ path: key }, assets[key]);
 			acc.push(obj);
 			return acc;
 		}, []);
 
+		assets.sort(function(a, b) {
+			if(isScript(a) && isScript(b)) {
+				return 1;
+			} else {
+				return -1;
+			}
+		});
+
+		this.assets = assets;
 		this.manifest = manifest;
 		this.push = push;
 	}

--- a/test/test.js
+++ b/test/test.js
@@ -22,6 +22,10 @@ describe("BundleManifest", function(){
 							"type": "script",
 							"weight": 2
 						},
+						"dist/bundles/app/puppies.js": {
+							"type": "script",
+							"weight": 2
+						},
 						"dist/bundles/app/app.css": {
 							"type": "style",
 							"weight": 1
@@ -54,11 +58,10 @@ describe("BundleManifest", function(){
 				assert.ok(this.route.assets instanceof Array, "It is an array");
 			});
 
-			it("filters to 1 script", function(){
-				debugger;
+			it("filters to 2 scripts", function(){
 				let route = this.route;
 				let scripts = route.assets.filter(a => a.type === "script");
-				assert.equal(scripts.length, 1);
+				assert.equal(scripts.length, 2);
 			});
 
 			it("filters to 2 styles", function(){
@@ -73,7 +76,7 @@ describe("BundleManifest", function(){
 				let html = route.toHTML(scripts);
 
 				assert.equal(html, `
-					<script src="/app/dist/bundles/app/app.js" async></script>
+					<script src="/app/dist/bundles/app/puppies.js" async></script><script src="/app/dist/bundles/app/app.js" async></script>
 				`.trim(), "correct scripts!");
 			});
 


### PR DESCRIPTION
Scripts should be ordered reverse, this script tags will work when async scripts are not supported. Closes #6